### PR TITLE
Upgrade ZT to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM caddy:${CADDDY_VERSION}-alpine as caddy
 
 FROM alpine:${ALPINE_VERSION} as zt-builder
 
-ARG ZT_VERSION=1.4.6
+ARG ZT_VERSION=1.6.4
 
 RUN apk add --no-cache --update clang clang-dev alpine-sdk linux-headers \
   && git clone --depth 1 --branch ${ZT_VERSION} https://github.com/zerotier/ZeroTierOne.git /src \


### PR DESCRIPTION
Latest ZT seems to compile and run fine on the base Alpine image, so this just upgrades the default `ZT_VERSION` arg value. Ideally, the GitHub actions might build a variety of versions and publish all of them, but there probably isn't actually a need.